### PR TITLE
Random Proof Search

### DIFF
--- a/configs/prooftrace_lm.json
+++ b/configs/prooftrace_lm.json
@@ -42,7 +42,7 @@
   "prooftrace_search_mcts_roll_count": 64,
 
   "prooftrace_dataset_dir": "./data/prooftrace",
-  "prooftrace_dataset_size": "small",
+  "prooftrace_dataset_size": "medium",
 
   "tensorboard_log_dir": null
 }

--- a/configs/prooftrace_lm.json
+++ b/configs/prooftrace_lm.json
@@ -25,7 +25,7 @@
   "prooftrace_lm_iota_sync_dir": null,
   "prooftrace_lm_iota_min_update_count": 12,
 
-  "prooftrace_search_type": "random",
+  "prooftrace_search_type": "beam",
   "prooftrace_search_fixed_gamma": 8,
   "prooftrace_search_step_timeout": 20.0,
 
@@ -42,7 +42,7 @@
   "prooftrace_search_mcts_roll_count": 64,
 
   "prooftrace_dataset_dir": "./data/prooftrace",
-  "prooftrace_dataset_size": "medium",
+  "prooftrace_dataset_size": "small",
 
   "tensorboard_log_dir": null
 }

--- a/configs/prooftrace_lm.json
+++ b/configs/prooftrace_lm.json
@@ -25,7 +25,7 @@
   "prooftrace_lm_iota_sync_dir": null,
   "prooftrace_lm_iota_min_update_count": 12,
 
-  "prooftrace_search_type": "beam",
+  "prooftrace_search_type": "random",
   "prooftrace_search_fixed_gamma": 8,
   "prooftrace_search_step_timeout": 20.0,
 

--- a/prooftrace/prooftrace.py
+++ b/prooftrace/prooftrace.py
@@ -152,12 +152,13 @@ class Term(BVT):
         """
         def v_term(term, bounded=[]):
             assert term.token() == '__v'
+            if skip_type:
+                return term.left.token()
+
             typ = term.right.value.type_string()
             tm = '(' + term.left.token() + typ + ')'
 
-            if skip_type:
-                tm = term.left.token()
-            if not de_bruijn or skip_type:
+            if not de_bruijn:
                 return tm
 
             if tm in bounded:

--- a/prooftrace/prooftrace.py
+++ b/prooftrace/prooftrace.py
@@ -146,22 +146,25 @@ class Term(BVT):
     def term_string(
             self,
             de_bruijn: bool = False,
+            skip_type: bool = False,
     ) -> str:
         """ `term_string` formats the Term BVT as a HOL Light term string
         """
         def v_term(term, bounded=[]):
             assert term.token() == '__v'
             typ = term.right.value.type_string()
-            term = '(' + term.left.token() + typ + ')'
+            tm = '(' + term.left.token() + typ + ')'
 
-            if not de_bruijn:
-                return term
+            if skip_type:
+                tm = term.left.token()
+            if not de_bruijn or skip_type:
+                return tm
 
-            if term in bounded:
+            if tm in bounded:
                 for i in reversed(range(len(bounded))):
-                    if term == bounded[i]:
+                    if tm == bounded[i]:
                         return '(b' + str(i) + typ + ')'
-            return term
+            return tm
 
         def dump(term, args, bounded):
             if term.token() == '__C':
@@ -184,8 +187,11 @@ class Term(BVT):
                 assert type(term.right.value) is Type
 
                 if len(args) == 0:
-                    return '((' + term.left.token() + ')' + \
-                        term.right.value.type_string() + ')'
+                    if skip_type:
+                        return '(' + term.left.token() + ')'
+                    else:
+                        return '((' + term.left.token() + ')' + \
+                            term.right.value.type_string() + ')'
                 else:
                     # This is an attempt at simplyfing terms as much as
                     # possible to make them readable.
@@ -197,8 +203,11 @@ class Term(BVT):
                             ' ' + args[1] + ')'
                         return tm
                     else:
-                        tm = '(((' + term.left.token() + ')' + \
-                            term.right.value.type_string() + ')'
+                        if skip_type:
+                            tm = '((' + term.left.token() + ')'
+                        else:
+                            tm = '(((' + term.left.token() + ')' + \
+                                term.right.value.type_string() + ')'
                         for a in args:
                             tm += ' ' + a
                         tm += ')'

--- a/prooftrace/repl/fusion.py
+++ b/prooftrace/repl/fusion.py
@@ -46,12 +46,13 @@ class Thm():
     def thm_string(
             self,
             de_bruijn: bool = False,
+            skip_type: bool = False,
     ) -> str:
         return "{} |- {}".format(
             ", ".join(sorted([
                 h.term_string(de_bruijn) for h in self._hypotheses
             ])),
-            self._conclusion.term_string(de_bruijn),
+            self._conclusion.term_string(de_bruijn, skip_type),
         )
 
 

--- a/prooftrace/search/random.py
+++ b/prooftrace/search/random.py
@@ -1,0 +1,155 @@
+import random
+import typing
+
+from prooftrace.prooftrace import \
+    ACTION_TOKENS, PREPARE_TOKENS, INV_ACTION_TOKENS, \
+    Action, ProofTraceActions
+
+from prooftrace.models.model import Model
+from prooftrace.repl.repl import REPL
+from prooftrace.repl.fusion import Thm
+from prooftrace.search.search import Search
+
+from utils.config import Config
+
+
+NON_PREPARE_TOKENS = {
+    k: v
+    for k, v in ACTION_TOKENS.items()
+    if k not in PREPARE_TOKENS
+}
+
+
+class Random(Search):
+    def __init__(
+            self,
+            config: Config,
+            model: Model,
+            ptra: ProofTraceActions,
+            repl: REPL,
+            target: Thm,
+    ) -> None:
+        super(Random, self).__init__(config, model, ptra, repl, target)
+
+        self._ptra = ptra.copy()
+        self._repl = repl.copy()
+        self._last_thm = None
+
+    def sample_term(
+            self,
+    ):
+        indices = [0] + [
+            i for i in range(self._ptra.len())
+            if self._ptra.actions()[i].value == 7
+        ]
+        return random.choice(indices)
+
+    def sample_theorem(
+            self,
+    ):
+        indices = [
+            i for i in range(1, self._ptra.len())
+            if self._ptra.actions()[i].value
+            in [2, 3] + list(NON_PREPARE_TOKENS.values())
+        ]
+        return random.choice(indices)
+
+    def sample_subst(
+            self,
+    ):
+        indices = [0] + [
+            i for i in range(self._ptra.len())
+            if self._ptra.actions()[i].value == 4
+        ]
+        return random.choice(indices)
+
+    def sample_subst_type(
+            self,
+    ):
+        indices = [0] + [
+            i for i in range(self._ptra.len())
+            if self._ptra.actions()[i].value == 5
+        ]
+        return random.choice(indices)
+
+    def step(
+            self,
+            offset: int = 0,
+    ) -> typing.Tuple[
+        bool, typing.Optional[ProofTraceActions], bool,
+    ]:
+        index, actions, arguments = self.preprocess_ptra(self._ptra)
+
+        tries = 32
+        candidate = None
+
+        for i in range(tries):
+            action = random.choice(list(NON_PREPARE_TOKENS.values()))
+
+            if INV_ACTION_TOKENS[action] == 'REFL':
+                left = self.sample_term()
+                right = 0
+            if INV_ACTION_TOKENS[action] == 'TRANS':
+                left = self.sample_theorem()
+                right = self.sample_theorem()
+            if INV_ACTION_TOKENS[action] == 'MK_COMB':
+                left = self.sample_theorem()
+                right = self.sample_theorem()
+            if INV_ACTION_TOKENS[action] == 'ABS':
+                left = self.sample_theorem()
+                right = self.sample_term()
+            if INV_ACTION_TOKENS[action] == 'BETA':
+                left = self.sample_term()
+                right = 0
+            if INV_ACTION_TOKENS[action] == 'ASSUME':
+                left = self.sample_term()
+                right = 0
+            if INV_ACTION_TOKENS[action] == 'EQ_MP':
+                left = self.sample_theorem()
+                right = self.sample_theorem()
+            if INV_ACTION_TOKENS[action] == 'DEDUCT_ANTISYM_RULE':
+                left = self.sample_theorem()
+                right = self.sample_theorem()
+            if INV_ACTION_TOKENS[action] == 'INST':
+                left = self.sample_theorem()
+                right = self.sample_subst()
+            if INV_ACTION_TOKENS[action] == 'INST_TYPE':
+                left = self.sample_theorem()
+                right = self.sample_subst_type()
+
+            a = Action.from_action(
+                INV_ACTION_TOKENS[action],
+                self._ptra.arguments()[left],
+                self._ptra.arguments()[right],
+            )
+
+            if self._ptra.seen(a):
+                continue
+
+            if not self._repl.valid(a):
+                continue
+
+            candidate = a
+            break
+
+        if candidate is not None:
+            thm = self._repl.apply(candidate)
+            candidate._index = thm.index()
+            argument = self._ptra.build_argument(
+                thm.concl(), thm.hyp(), thm.index(),
+            )
+            self._ptra.append(candidate, argument)
+
+            self._last_thm = thm
+        else:
+            return True, self._ptra, False
+
+        if self._target.thm_string(True) == thm.thm_string(True):
+            return True, self._ptra, True
+
+        return False, self._ptra, False
+
+    def last_thm(
+            self,
+    ) -> typing.Optional[Thm]:
+        return self._last_thm

--- a/prooftrace/tools.py
+++ b/prooftrace/tools.py
@@ -18,6 +18,7 @@ from prooftrace.repl.repl import REPL
 from prooftrace.search.beam import Beam
 from prooftrace.search.particle_filter import ParticleFilter
 from prooftrace.search.policy_sample import PolicySample
+from prooftrace.search.random import Random
 
 from utils.config import Config
 from utils.log import Log
@@ -251,7 +252,7 @@ def search():
     dataset_dir = os.path.join(
         os.path.expanduser(config.get('prooftrace_dataset_dir')),
         config.get('prooftrace_dataset_size'),
-        'test_traces'
+        'train_traces'
     )
 
     assert os.path.isdir(dataset_dir)
@@ -331,8 +332,9 @@ def search():
         Log.out("TARGET", {
             'name': ground.name(),
             'prepare_length': ground.prepare_len(),
-            'length': ground.action_len(),
+            'action_length': ground.action_len(),
             'summary': ground.summary(offset),
+            'theorem': target.thm_string(False, True),
         })
 
         search = None
@@ -342,25 +344,30 @@ def search():
             search = ParticleFilter(config, model, ptra, repl, target)
         if config.get('prooftrace_search_type') == 'policy_sample':
             search = PolicySample(config, model, ptra, repl, target)
+        if config.get('prooftrace_search_type') == 'random':
+            search = Random(config, model, ptra, repl, target)
         assert search is not None
 
-        depth = fixed_gamma * 4
+        depth = config.get('prooftrace_sequence_length') - ground.prepare_len()
+        depth = ground.action_len()
+        if fixed_gamma != 0 and 2 * fixed_gamma < depth:
+            depth = fixed_gamma * 4
 
         for i in range(depth):
             step_start = time.time()
             done, ptra, proved = search.step(offset)
             step_end = time.time()
 
-            Log.out('STEP', {
-                'i': i,
-                'done': done,
-                'proved': proved,
-                'time': "{:.2f}".format(step_end - step_start),
-            })
+            # Log.out('STEP', {
+            #     'i': i,
+            #     'done': done,
+            #     'proved': proved,
+            #     'time': "{:.2f}".format(step_end - step_start),
+            # })
             if done:
                 if proved:
                     Log.out("DEMONSTRATED", {
-                        'theorem': thm.thm_string(True),
+                        'theorem': target.thm_string(True),
                     })
                 break
 
@@ -371,3 +378,7 @@ def search():
         Log.out("FINISH", {
             'summary': ptra.summary(offset),
         })
+        if config.get('prooftrace_search_type') == 'random':
+            Log.out("THEOREM", {
+                'theorem': search.last_thm().thm_string(False, True)
+            })

--- a/prooftrace/tools.py
+++ b/prooftrace/tools.py
@@ -378,7 +378,8 @@ def search():
         Log.out("FINISH", {
             'summary': ptra.summary(offset),
         })
-        if config.get('prooftrace_search_type') == 'random':
+        if config.get('prooftrace_search_type') == 'random' \
+                and search.last_thm() is not None:
             Log.out("THEOREM", {
                 'theorem': search.last_thm().thm_string(False, True)
             })

--- a/prooftrace/tools.py
+++ b/prooftrace/tools.py
@@ -367,7 +367,7 @@ def search():
             if done:
                 if proved:
                     Log.out("DEMONSTRATED", {
-                        'theorem': target.thm_string(True),
+                        'theorem': target.thm_string(False, True),
                     })
                 break
 

--- a/prooftrace/tools.py
+++ b/prooftrace/tools.py
@@ -252,7 +252,7 @@ def search():
     dataset_dir = os.path.join(
         os.path.expanduser(config.get('prooftrace_dataset_dir')),
         config.get('prooftrace_dataset_size'),
-        'train_traces'
+        'test_traces'
     )
 
     assert os.path.isdir(dataset_dir)
@@ -350,7 +350,7 @@ def search():
 
         depth = config.get('prooftrace_sequence_length') - ground.prepare_len()
         depth = ground.action_len()
-        if fixed_gamma != 0 and 2 * fixed_gamma < depth:
+        if fixed_gamma != 0 and 4 * fixed_gamma < depth:
             depth = fixed_gamma * 4
 
         for i in range(depth):


### PR DESCRIPTION
- Add a `random` search policy that randomly samples valid theorems through REPL eval.
- Log generated theorems with: `prooftrace_search configs/prooftrace_lm.json --device=cpu | grep THEOREM`.